### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "80:80"
       - "443:443"
     networks:
-      - default
+      - proxy
       # - internal
     labels:
       - "traefik.enable=true"
@@ -39,8 +39,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
 networks:
-  default:
-    name: proxy
+  proxy:
+    external: true # this may not actually be necessary, I would suggest testing with/without this
   # internal:
   #   name: internal
   #   external: true


### PR DESCRIPTION
here is what the config looked like on a gateway that works with this traefik config: 
```
  main-gateway:
    <<: [ *default-logging ]
    image: inductiveautomation/ignition:${IGNITION_VERSION}
    hostname: main-gateway
    container_name: ignition-${GATEWAY_NAME}-${ENV}
    user: 0:0
    volumes:
      - ./gw-init/${ENV}/gateway.gwbk:/restore.gwbk
      # FOR IGNITION PROJECTS IN THE GATEWAY:
      # Structure: - ./gw-projects/project-name:/usr/local/bin/ignition/data/projects/project-name
      - ./gw-projects/global:/usr/local/bin/ignition/data/projects/global
      - ./gw-projects/IADemo:/usr/local/bin/ignition/data/projects/IADemo
      - ./gw-projects/OnlineDemo:/usr/local/bin/ignition/data/projects/OnlineDemo
      - ./gw-projects/samplequickstart:/usr/local/bin/ignition/data/projects/samplequickstart
      - ./gw-projects/TagDashboard:/usr/local/bin/ignition/data/projects/TagDashboard
      # FOR ADDITIONAL MODULES IN THE GATEWAY:
      # Structure: - ./module-init/Module-Name.modl:/usr/local/bin/ignition/user-lib/modules/Module-Name.modL
      - ./module-init/MQTT-Engine-signed.modl:/usr/local/bin/ignition/user-lib/modules/MQTT-Engine.modl
      - ./module-init/Tag-CICD.modl:/usr/local/bin/ignition/user-lib/modules/Tag-CICD.modl
    env_file:
      - ./basic.env
    labels:
      - traefik.enable=true
      - traefik.hostname=${GATEWAY_NAME}-${ENV}
    command: >
      -n ${GATEWAY_NAME}-${ENV}
      -r /restore.gwbk
      -h 80
      -s 443
      -a ${GATEWAY_NAME}-${ENV}.pde-103.ia.local
      --
      -Dignition.projects.scanFrequency=10
    networks:
      - proxy

networks:
  proxy:
    external: true
```

The changes in this PR, combined with the snippet above should be all you need to get the reverse proxy working