### PR TITLE
chore: make keys strings instead of bools

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,16 @@ services:
     restart: always
     environment:  # https://docs.traefik.io/reference/static-configuration/env/
       TRAEFIK_ENTRYPOINTS_WEB_ADDRESS: :80
-      TRAEFIK_API_DASHBOARD: true
-      TRAEFIK_PROVIDERS_DOCKER: true
-      TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: false
+      TRAEFIK_API_DASHBOARD: "true"
+      TRAEFIK_PROVIDERS_DOCKER: "true"
+      TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: "false"
       TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE: >
         Host(`{{ or (index .Labels "traefik.hostname")
                     (index .Labels "com.docker.compose.service")
                     .Name 
               }}.localtest.me`)
-      TRAEFIK_PROVIDERS_DOCKER_ALLOWEMPTYSERVICES: true
-      TRAEFIK_PROVIDERS_DOCKER_NETWORK: proxy
+      TRAEFIK_PROVIDERS_DOCKER_ALLOWEMPTYSERVICES: "true"
+      TRAEFIK_PROVIDERS_DOCKER_NETWORK: default
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 #
 # ===Usage===
 # Bring up the Traefik Reverse Proxy:
-#   docker compose -f stack-proxy.yml -p proxy up -d
+#   docker compose up -d
 #
 # Bring down and stop the Reverse Proxy:
 #   docker compose down
@@ -24,12 +24,12 @@ services:
                     .Name 
               }}.localtest.me`)
       TRAEFIK_PROVIDERS_DOCKER_ALLOWEMPTYSERVICES: "true"
-      TRAEFIK_PROVIDERS_DOCKER_NETWORK: default
+      TRAEFIK_PROVIDERS_DOCKER_NETWORK: proxy
     ports:
       - "80:80"
       - "443:443"
     networks:
-      - default
+      - proxy
     labels:
       - "traefik.enable=true"
       - "traefik.hostname=proxy"
@@ -37,5 +37,4 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 networks:
-  default:
-    name: proxy
+  proxy:


### PR DESCRIPTION
* update values to be strings instead of bools
* fixes bug on linux where traefik failed to start due to necesity of string or int values